### PR TITLE
Deserialize Option and newtypes transparently

### DIFF
--- a/nvpair/src/de.rs
+++ b/nvpair/src/de.rs
@@ -156,9 +156,23 @@ impl<'de, 'a> de::Deserializer<'de> for &'a mut ValueDeserializer<'de> {
         }
     }
 
+    fn deserialize_newtype_struct<V>(self, _name: &'static str, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_newtype_struct(self)
+    }
+
+    fn deserialize_option<V>(self, visitor: V) -> Result<V::Value>
+    where
+        V: Visitor<'de>,
+    {
+        visitor.visit_some(self)
+    }
+
     forward_to_deserialize_any! {
         bool i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 char str string
-        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        bytes byte_buf unit unit_struct seq tuple
         tuple_struct map struct enum identifier ignored_any
     }
 }


### PR DESCRIPTION
When deserializing an nvlist, if the struct calls for an Option or a
newtype, expect simply the wrapped value in the nvlist (or absent from
the nvlist in the case of an Option).  This allows us to deserialize a
DATA_TYPE_UINT64 nvpair as a `struct NewType(u64)` or an `Option<u64>`.
