### PR TITLE
Change from_nvlist to accept a NvListRef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -88,7 +88,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
 name = "nvpair"
-version = "0.5.1-delphix0"
+version = "0.5.2-delphix0"
 dependencies = [
  "cstr-argument",
  "foreign-types",

--- a/nvpair/Cargo.toml
+++ b/nvpair/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nvpair"
-version = "0.5.1-delphix0"
+version = "0.5.2-delphix0"
 authors = ["Cody P Schafer <dev@codyps.com>"]
 include = ["**/*.rs", "Cargo.toml"]
 documentation = "https://docs.rs/nvpair"

--- a/nvpair/src/de.rs
+++ b/nvpair/src/de.rs
@@ -9,10 +9,11 @@ pub fn from_bytes<T>(buf: &[u8]) -> Result<T>
 where
     T: DeserializeOwned,
 {
-    from_nvlist(&NvList::try_unpack(buf)?)
+    let nvl = NvList::try_unpack(buf)?;
+    from_nvlist(&nvl)
 }
 
-pub fn from_nvlist<'a, T>(s: &'a NvList) -> Result<T>
+pub fn from_nvlist<'a, T>(s: &'a NvListRef) -> Result<T>
 where
     T: Deserialize<'a>,
 {

--- a/zfs-core/Cargo.toml
+++ b/zfs-core/Cargo.toml
@@ -13,7 +13,7 @@ edition = "2018"
 v2_00 = []
 
 [dependencies]
-nvpair = { path = "../nvpair", version = "0.5.1-delphix0" }
+nvpair = { path = "../nvpair", version = "0.5.2-delphix0" }
 zfs-core-sys = { path = "../zfs-core-sys", version = "0.5.0" }
 cstr-argument = "0.1"
 foreign-types = "0.5.0"


### PR DESCRIPTION
This PR changes the `from_nvlist` function to accept an NvListRef instead a raw NvList. This makes the API more usable in more cases, and changes none of the functionality. Works in conjunction with most existing code, since there is automatic  conversion from an NvList to an NvListRef.