### PR TITLE
NvList is Sync

### DIFF
--- a/nvpair/src/lib.rs
+++ b/nvpair/src/lib.rs
@@ -489,7 +489,7 @@ impl NvEncoding {
 
 foreign_type! {
     /// An `NvList`
-    pub unsafe type NvList: Send {
+    pub unsafe type NvList: Send + Sync {
         type CType = sys::nvlist;
         fn drop = sys::nvlist_free;
     }


### PR DESCRIPTION
The NvList type does not have interior mutability, so to modify it,
exclusive access is required (e.g. `NvList` or `&mut NvListRef`).
Therefore, a shared reference to NvList (i.e. `&NvListRef`) can be sent
to other threads, and accessed concurrently from multiple threads.  So
NvList can be marked `Sync`.
